### PR TITLE
remove duplicate ember-window-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4088,7 +4088,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ember-window-mock/-/ember-window-mock-0.2.0.tgz",
       "integrity": "sha1-hQeXGyEGWC7wJKukEuDwNTyxquc=",
-      "dev": true,
       "optional": true,
       "requires": {
         "broccoli-funnel": "2.0.1",
@@ -4099,7 +4098,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
           "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
-          "dev": true,
           "optional": true,
           "requires": {
             "array-equal": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-resolver": "^4.0.0",
     "ember-sinon": "^1.0.1",
     "ember-source": "~2.18.0",
-    "ember-window-mock": "^0.2.0",
     "eslint-config-peopleconnect": "^1.0.0",
     "eslint-config-peopleconnect-ember": "^2.0.1",
     "eslint-config-sane": "^0.4.2",


### PR DESCRIPTION
NPM gives a warning. Apparently optionalDependencies are always installed locally, so we are good.