### PR TITLE
fix: improved test for window versus passed element

### DIFF
--- a/addon/services/scroller.js
+++ b/addon/services/scroller.js
@@ -167,8 +167,8 @@ export default Service.extend({
   },
 
   getScrollTo(container) {
-    // if scrollTo is a function, it's most likely the window
-    if (typeof container.scrollTo === 'function') {
+    // Check if container is the window
+    if (container.self === window) {
       return container.scrollTo;
     // otherwise it's an element
     } else {


### PR DESCRIPTION
Fix for #60 

I was also encountering passed elements that returned invalid functions from `scrollTo`. 

Note that unit tests are failing locally for me in both master and this PR.